### PR TITLE
Remove duplicate Swagger registration

### DIFF
--- a/src/Presentation/QuoteManagement.API/Program.cs
+++ b/src/Presentation/QuoteManagement.API/Program.cs
@@ -16,7 +16,6 @@ builder.Services.AddPersistenceServices(builder.Configuration);
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 
 // Add CORS
 builder.Services.AddCors(options =>


### PR DESCRIPTION
## Summary
- remove redundant `AddSwaggerGen` call from the API startup

## Testing
- `dotnet restore`
- `dotnet run --urls=http://localhost:5050` (manual check of `/swagger` UI)


------
https://chatgpt.com/codex/tasks/task_e_6845707d8b748327ba176875908a8b88