### PR TITLE
Show more options icon on quote card hover

### DIFF
--- a/src/Presentation/QuoteManagement.API/ClientApp/src/app/pages/feed/feed.component.html
+++ b/src/Presentation/QuoteManagement.API/ClientApp/src/app/pages/feed/feed.component.html
@@ -63,12 +63,12 @@
   <!-- Quotes Grid -->
   <div *ngIf="!loading" class="max-w-6xl mx-auto px-6 py-8">
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      <div class="quote-card bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow" *ngFor="let quote of filteredQuotes; let i = index">
+      <div class="quote-card group bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow" *ngFor="let quote of filteredQuotes; let i = index">
         <!-- Header with More Options -->
         <div class="flex justify-between items-start mb-4">
           <div class="flex-1"></div>
           <div class="relative">
-            <button class="text-gray-400 hover:text-gray-600 p-1 rounded transition-colors" (click)="toggleQuoteMenu(quote.id)" [attr.aria-expanded]="isQuoteMenuOpen(quote.id)" aria-label="More options">
+            <button class="more-options-btn text-gray-400 hover:text-gray-600 p-1 rounded transition-colors" (click)="toggleQuoteMenu(quote.id)" [attr.aria-expanded]="isQuoteMenuOpen(quote.id)" [ngClass]="{ 'is-open': isQuoteMenuOpen(quote.id) }" aria-label="More options">
               <i class="pi pi-ellipsis-v"></i>
             </button>
 

--- a/src/Presentation/QuoteManagement.API/ClientApp/src/app/pages/feed/feed.component.scss
+++ b/src/Presentation/QuoteManagement.API/ClientApp/src/app/pages/feed/feed.component.scss
@@ -511,3 +511,15 @@ button {
 .group:focus .quote-menu {
   pointer-events: auto;          /* reactivate when visible */
 }
+
+// Hide the more options trigger until the card is hovered or the menu is open
+.more-options-btn {
+  @apply opacity-0 transition-opacity duration-150;
+  pointer-events: none;
+}
+
+.quote-card:hover .more-options-btn,
+.more-options-btn.is-open {
+  @apply opacity-100;
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Summary
- only reveal the quote card menu button on hover
- keep the icon visible when the menu is opened

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test` in `ClientApp` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c0a4ff488327ad99ca13c7bcc7f1